### PR TITLE
Handle relPath from file

### DIFF
--- a/src/utils/FileManager.js
+++ b/src/utils/FileManager.js
@@ -230,9 +230,9 @@ class FileManager {
       }
     }
     const { filePath, relPath, moduleName } = file;
-    relPath = relPath.replace(this.srcDir, ''); // Sometimes relPath returns full path to source dir
     const isModConf = filePath.indexOf('conf') >= 0 && moduleName;
-    let destPath = path.join(this.buildDir, relPath);
+    const rPath = relPath.replace(this.srcDir, ''); // Sometimes relPath returns full path to source dir
+    let destPath = path.join(this.buildDir, rPath);
     const srcFileExists = fs.existsSync(filePath);
     const destFileExists = fs.existsSync(destPath);
 

--- a/src/utils/FileManager.js
+++ b/src/utils/FileManager.js
@@ -230,6 +230,7 @@ class FileManager {
       }
     }
     const { filePath, relPath, moduleName } = file;
+    relPath = relPath.replace(this.srcDir, ''); // Sometimes relPath returns full path to source dir
     const isModConf = filePath.indexOf('conf') >= 0 && moduleName;
     let destPath = path.join(this.buildDir, relPath);
     const srcFileExists = fs.existsSync(filePath);


### PR DESCRIPTION
As noted in the source for `utils/FileManager`, sometimes relPath from file returns the absolute path to the directory the file is contained in. I added a replace() to remove the first (absolute) part of that path.